### PR TITLE
updated git url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This example was tested on Red Hat OpenShift 4.16.24 & Red Hat OpenShift AI v2.1
 ### Clone
 
 ```
-git clone https://github.com/rh-ai-quickstart/vllm-cpu.git && \
+git clone https://github.com/rh-ai-quickstart/llm-cpu-serving.git && \
     cd vllm-cpu/  
 ```
 


### PR DESCRIPTION
Install -> Clone in documentation fails since git URL is outdated. Updated the URL to match the renamed repository.