### PR TITLE
Update images and workbench for OpenShift AI 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,20 @@ Red Hat uses Arcade software to create interactive demos. Check out
 ### Recommended hardware requirements 
 
 - No GPU needed! 🤖
-- 8 cores 
-- 8 Gi 
+- 32 cores 
+- 64 Gi 
 - Storage: 5Gi
 
-Note: This version is compiled for Intel CPU's (preferably with AWX512 enabled to be able to run compressed models as well, but optional).  
+Adjust the value of CPU and memory in `helm/values.yaml` as desired.
+
+Note: This version is compiled for Intel CPU's (preferably with AVX512 enabled to be able to run compressed models as well, but optional).  
 Here's an example machine from AWS that works well: [https://instances.vantage.sh/aws/ec2/m6i.4xlarge](https://instances.vantage.sh/aws/ec2/m6i.4xlarge)
 
 ### Minimum software requirements
 
 - Red Hat OpenShift 4.16.24 or later
-- Red Hat OpenShift AI 2.16.2 or later
-- Dependencies for [Single-model server](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.16/html/installing_and_uninstalling_openshift_ai_self-managed/installing-the-single-model-serving-platform_component-install#configuring-automated-installation-of-kserve_component-install):
+- Red Hat OpenShift AI 3.3.0 or later
+- Dependencies for Single-model server:
     - Red Hat OpenShift Service Mesh
     - Red Hat OpenShift Serverless
 
@@ -76,6 +78,8 @@ Here's an example machine from AWS that works well: [https://instances.vantage.s
 
 Follow the below steps to deploy and test the HR assistant.
 
+This example was tested on Red Hat OpenShift 4.21.8 & Red Hat OpenShift AI v3.3.0.
+
 ### Clone
 
 ```
@@ -83,12 +87,12 @@ git clone https://github.com/rh-ai-quickstart/llm-cpu-serving.git && \
     cd llm-cpu-serving/  
 ```
 
-<!-- ### (Optional) Update storage class name
+### (Optional) Update storage class name
 
 If needed, update storage class name in `helm/values.yaml`.
 ```
 storageClassName: gp3-csi
-``` -->
+```
 
 ### Create the project
 
@@ -120,12 +124,9 @@ tinyllama-1b-cpu-predictor-544bdf75f9-x9fwh   2/2     Running     0          75s
 
 ### Test
 
-You can get the OpenShift AI Dashboard URL by:
-```bash
-oc get routes rhods-dashboard -n redhat-ods-applications
-```
+From the OpenShift Console, go to the App Switcher / Waffle in the upper right and go to the Red Hat OpenShift AI Dashboard.
 
-Once inside the dashboard, navigate to Data Science Projects -> tinyllama-cpu-demo (or what you called your ${PROJECT} if you changed from default).
+Once inside the dashboard, navigate to Data Science Projects or Projects -> hr-assistant (or what you called your ${PROJECT} if you changed from default).
 
 ![OpenShift AI Projects](docs/images/rhoai-1.png)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ If needed, update storage class name in `helm/values.yaml`.
 storageClassName: gp3-csi
 ```
 
+### (Optional) Configure LD_PRELOAD
+
+The default LD_PRELOAD for this image is setting an unsupported memory
+allocator jemalloc. So setting this LD_PRELOAD to libomp overrides that
+setting. jemalloc is set for pyarrow compatibility, if you require pyarrow
+usage in this image jemalloc should be set in LD_PRELOAD alongside libomp
+but vLLM will have degraded performance.
+
+If needed, configure the LD_PRELOAD variable in `helm/servingruntime.yaml`
+```
+env:
+  - name: LD_PRELOAD
+    value: "/usr/lib64/libomp.so"
+```
+
 ### Create the project
 
 ```bash

--- a/helm/templates/servingruntime.yaml
+++ b/helm/templates/servingruntime.yaml
@@ -26,6 +26,9 @@ spec:
         - {{ .Values.model.name }}
       image: {{ .Values.images.vllmRuntime.repository }}:{{ .Values.images.vllmRuntime.tag }}
       name: kserve-container
+      env:
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "2"
       ports:
         - containerPort: 8080
           name: http1

--- a/helm/templates/workbench.yaml
+++ b/helm/templates/workbench.yaml
@@ -3,14 +3,21 @@ apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
   annotations:
+    {{- if .Capabilities.APIVersions.Has "datasciencecluster.opendatahub.io/v2" }}
+    notebooks.opendatahub.io/inject-auth: 'true'
+    {{- else }}
     notebooks.opendatahub.io/inject-oauth: 'true'
+    {{- end }}
     opendatahub.io/image-display-name: AnythingLLM
+    opendatahub.io/notebook-image-name: "anythingllm-workbench"
+    opendatahub.io/workbench-image-namespace: {{ .Release.Namespace }}
     opendatahub.io/accelerator-name: ''
     openshift.io/description: ''
     openshift.io/display-name: AnythingLLM
-    notebooks.opendatahub.io/last-image-selection: '{{ .Release.Namespace }}/custom-anythingllm:1.8.5'
+    notebooks.opendatahub.io/last-image-selection: 'anythingllm-workbench:{{ .Values.images.anythingllm.tag }}'
     notebooks.opendatahub.io/last-size-selection: Small
     opendatahub.io/username: quickstart@redhat.com
+    
   name: anythingllm
   labels:
     app: anythingllm
@@ -89,6 +96,7 @@ spec:
                 name: tinyllama-vllm-cpu
           image: "{{ .Values.images.anythingllm.repository }}:{{ .Values.images.anythingllm.tag }}"
           workingDir: /opt/app-root/src
+        {{- if not (.Capabilities.APIVersions.Has "datasciencecluster.opendatahub.io/v2") }}
         - resources:
             limits:
               cpu: 100m
@@ -146,7 +154,8 @@ spec:
             - '--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
             - '--email-domain=*'
             - '--skip-provider-button'
-            - '--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org","resourceName":"anythingllm","namespace":"{{ .Release.Namespace }}"}'
+            - '--openshift-sar={"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org","resourceName":"anythingllm","namespace":"{{ .Release.Namespace }}"}'    
+        {{- end }}
         - name: anythingllm-automation
           image: keinos/sqlite3:latest
           command: ["/bin/sh", "-c"]
@@ -238,11 +247,4 @@ spec:
             name: workbench-trusted-ca-bundle
             optional: true
           name: trusted-ca
-        - name: oauth-config
-          secret:
-            defaultMode: 420
-            secretName: anythingllm-oauth-config
-        - name: tls-certificates
-          secret:
-            defaultMode: 420
-            secretName: anythingllm-tls
+

--- a/helm/templates/workbench.yaml
+++ b/helm/templates/workbench.yaml
@@ -17,7 +17,6 @@ metadata:
     notebooks.opendatahub.io/last-image-selection: 'anythingllm-workbench:{{ .Values.images.anythingllm.tag }}'
     notebooks.opendatahub.io/last-size-selection: Small
     opendatahub.io/username: quickstart@redhat.com
-    
   name: anythingllm
   labels:
     app: anythingllm
@@ -247,4 +246,4 @@ spec:
             name: workbench-trusted-ca-bundle
             optional: true
           name: trusted-ca
-
+          

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,11 +49,11 @@ aiLifecoach:
 
 images:
   vllmRuntime:
-    repository: "quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
-    tag: "0.3"
+    repository: "quay.io/vllm/automation-vllm"
+    tag: "0.18.0rc1.dev7_rhaiv.0.ge974742fb.cpu"
   anythingllm:
     repository: "quay.io/rh-aiservices-bu/anythingllm-workbench"
-    tag: "1.8.5"
+    tag: "1.9.1"
 
 model:
   storageUri: "oci://quay.io/rh-aiservices-bu/tinyllama:1.0"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,7 +50,7 @@ aiLifecoach:
 images:
   vllmRuntime:
     repository: "quay.io/vllm/automation-vllm"
-    tag: "0.18.0rc1.dev7_rhaiv.0.ge974742fb.cpu"
+    tag: "0.18.0_rhaiv.5.cpu"
   anythingllm:
     repository: "quay.io/rh-aiservices-bu/anythingllm-workbench"
     tag: "1.9.1"


### PR DESCRIPTION
This PR updates the LLM CPU serving quickstart to improve stability and compatibility with OpenShift AI 3.3.
Changes include:
- Temporarily switch the vLLM CPU image to quay.io/vllm/automation:vllm0.18.0rc1.dev7_rhai_v0e974742fb_cpu until an official image is available.
- Update anythingllm-workbench image to v1.9.1.
- Apply required workbench configuration changes for OpenShift AI 3.3 compatibility.
- Refresh the README with updated resource requirements, supported versions, and installation instructions.