### PR TITLE
Add Makefile for RHDP deploy integration

### DIFF
--- a/helm/Makefile
+++ b/helm/Makefile
@@ -1,0 +1,14 @@
+NAMESPACE ?= llm-cpu-serving
+RELEASE ?= vllm-cpu
+
+.PHONY: install uninstall
+
+install:
+	helm install $(RELEASE) . \
+		--namespace $(NAMESPACE) \
+		--create-namespace \
+		--set username=$$(oc whoami) \
+		--wait --timeout 10m
+
+uninstall:
+	helm uninstall $(RELEASE) --namespace $(NAMESPACE)


### PR DESCRIPTION
## Summary

Adds `install` and `uninstall` Makefile targets to `helm/` for RHDP `quickstart_deploy_via_make` integration. Without this, tenant provisioning fails with `No rule to make target 'install'`.

## Test plan

- [ ] `make install NAMESPACE=test` runs `helm install` successfully
- [ ] `make uninstall NAMESPACE=test` runs `helm uninstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)